### PR TITLE
Fix memory leak

### DIFF
--- a/src/Phake/CallRecorder/Recorder.php
+++ b/src/Phake/CallRecorder/Recorder.php
@@ -103,6 +103,7 @@ class Phake_CallRecorder_Recorder
     {
         $this->calls     = array();
         $this->positions = array();
+        $this->unverifiedCalls = array();
     }
 
     /**


### PR DESCRIPTION
Phake's "resetStatic" didn't reset the unverified calls list.
This lead to a memory leak when running multiple tests